### PR TITLE
Adding GitHubRaw CDN

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ logo: 'images/logo'
 # Template Values: DO NOT TOUCH
 
 # Bibliography
-csl: https://www.zotero.org/styles/journal-of-the-acm # See https://www.zotero.org/styles for more styles.
+csl: https://cdn.githubraw.com/DataKritter/zotero-citation-styles/a871ea01/association-for-computing-machinery.csl # See https://www.zotero.org/styles for more styles.
 bibliography: references.bib # See https://github.com/jgm/pandoc-citeproc/blob/master/man/pandoc-citeproc.1.md for more formats.
 suppress-bibliography: false
 link-citations: true


### PR DESCRIPTION
Substituting the old Zotero GitHub using githubraw as a CDN to serve the CSL files required for building the thesis document, as Zotero proper isn't answering our calls.